### PR TITLE
Revert "#167092464:  Remove userId param from get profile route"

### DIFF
--- a/server/controller/profile.js
+++ b/server/controller/profile.js
@@ -68,11 +68,8 @@ class ProfileController {
    *
    */
   static async getProfile(req, res, next) {
-    const { userId } = req.user;
     try {
-      const user = await User.findByPk(userId, {
-        include: [{ model: Profile, as: 'profile' }],
-      });
+      const user = await User.findByPk(req.params.userId, { include: [{ model: Profile, as: 'profile' }] });
       if (!user) {
         return res.status(404).json({
           status: 404,

--- a/server/routes/api/profiles.js
+++ b/server/routes/api/profiles.js
@@ -9,6 +9,6 @@ const { newProfileValidator } = profileValidator;
 const { editProfile, getProfile } = ProfileController;
 
 router.put('/profiles', verifyToken, newProfileValidator, editProfile);
-router.get('/profiles/', verifyToken, getProfile);
+router.get('/profiles/:userId', verifyToken, getProfile);
 
 export default router;

--- a/server/test/index.js
+++ b/server/test/index.js
@@ -21,7 +21,7 @@ describe('Testing ErrorHandlers/Middlewares', () => {
 
   it('Should return an error if verifyToken middleware is passed an invalid Token', (done) => {
     request(server)
-      .get('/api/profiles')
+      .get('/api/profiles/14')
       .set('authorization', 'invalidtokenstring')
       .end((err, res) => {
         expect(res.body).to.be.a('object');


### PR DESCRIPTION

### What does this PR do?

* Revert changes to the state of develop before `"#167092464:  Remove userId param from get profile route"`

### Description of Task to be completed?

* add userId to the get profile route
* update the test to match the changes 

### Any background context you want to provide?

After making the changes, It cleared that the userId is needed no for a user getting their profile but for user's getting the profile of others. For that to work the userId is needed.

### What are the relevant Github issues?

N/A

### Questions:

N/A